### PR TITLE
Skip handling :scope on non-element nodes

### DIFF
--- a/src/dom4.js
+++ b/src/dom4.js
@@ -721,6 +721,7 @@
         return find(this, querySelectorAll, css);
       };
       function find(node, method, css) {
+        if (node.type != document.ELEMENT_NODE) return method.call(node, css);
         node.setAttribute(dataScope, null);
         var result = method.call(
           node,


### PR DESCRIPTION
Document fragments do not have attributes, so the code would throw an exception trying to call setAttribute on non-element nodes.